### PR TITLE
Terraform AMI, and Ansible/packer provisioning

### DIFF
--- a/ami_README.md
+++ b/ami_README.md
@@ -68,3 +68,5 @@ This playbook is specific to installing the dependencies of Jenkins and Jenkins 
 
 ### Standard Instance (standard_instance.yaml)
 
+This is a base image on which the app will run during the deployment stage, as well as being a standard base image on which the Jenkins (and others) will build on top of.
+* The docker dependencies as well as the docker key as well

--- a/provisioning/jenkins.yaml
+++ b/provisioning/jenkins.yaml
@@ -36,3 +36,14 @@
         name: jenkins
         state: present
         force: yes
+
+    - name: Add jenkins user to the docker group
+      user:
+        name: jenkins
+        groups: 'docker'
+        append: yes
+
+    - name: Restart docker.service
+      service:
+        name: docker
+        state: restarted

--- a/provisioning/main_jenkins.yaml
+++ b/provisioning/main_jenkins.yaml
@@ -3,8 +3,9 @@
 - name: Netdata setup
   import_playbook: netdata_setup.yaml
 
+- name: Install docker etc
+  import_playbook: standard_instance.yaml
+
 - name: EC2 instance setup
   import_playbook: jenkins.yaml
 
-- name: Install docker etc
-  import_playbook: standard_instance.yaml

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,7 +12,7 @@ variable "ami_db" {
 }
 
 variable "ami_jenkins" {
-  default = "ami-0c38f3ca0f0043f49"
+  default = "ami-0b92ece2ce5d6163d"
 }
 
 variable "ami_ubuntu" {


### PR DESCRIPTION
Changed the AMI used for Jenkins to a more updated one, with the docker working. 

Updated the ansible packer provisioning script to get the jenkins user's docker permissions to be correct on this new blank instance